### PR TITLE
Add tooltips to status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A minimal GNOME Shell extension that displays configurable status indicators for
 - **Zero or more indicators**: Add/remove status indicators dynamically
 - **Simple emoji icons**: Static, non-distracting indicators (default: ✅ ready, ⚠️ working, ⛔ waiting)
 - **Customizable**: Configure indicator names, icons, and positioning
+- **Tooltips**: Hover over indicators to see their names (project names, tool names, etc.)
 - **D-Bus control**: Programmatic control via D-Bus for external applications
 - **Lightweight**: Minimal resource usage and clean UI integration
 - **Configurable positioning**: Place indicators in left, center, or right panel areas

--- a/extension.js
+++ b/extension.js
@@ -42,6 +42,9 @@ class StatusIndicator extends St.BoxLayout {
             });
             this.add_child(this._textLabel);
         }
+
+        // Set tooltip to show indicator name
+        this.set_tooltip_text(this._name);
     }
 
     setStatus(status) {
@@ -94,6 +97,9 @@ class StatusIndicator extends St.BoxLayout {
         if (this._textLabel) {
             this._textLabel.set_text(this._name);
         }
+
+        // Update tooltip with new name
+        this.set_tooltip_text(this._name);
     }
 });
 
@@ -275,18 +281,27 @@ export default class StatusWidgetExtension extends Extension {
         let targetBox;
         let index = -1;
 
+        // The original code uses index = -1 for 'left' and 'center', and index = 0 for 'right'.
+        // In St.BoxLayout, index = -1 means "append at the end", and index = 0 means "insert at the beginning".
+        // This is likely to ensure the widget appears at the far right in the right box (which is the default GNOME convention),
+        // and at the end in left/center boxes (so it doesn't push out other items).
+        // For clarity, let's add a comment and make the intent explicit:
+
         switch (position) {
             case 'left':
                 targetBox = Main.panel._leftBox;
+                // Insert at end so it appears rightmost in the left box
                 index = -1;
                 break;
             case 'center':
                 targetBox = Main.panel._centerBox;
+                // Insert at end so it appears rightmost in the center box
                 index = -1;
                 break;
             case 'right':
             default:
                 targetBox = Main.panel._rightBox;
+                // Insert at beginning so it appears leftmost in the right box (GNOME convention)
                 index = 0;
                 break;
         }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -23,6 +23,7 @@ global.imports = {
                     this.vertical = params.vertical;
                     this.children = [];
                     this.visible = true;
+                    this.tooltip_text = '';
                 }
                 
                 add_child(child) {
@@ -34,6 +35,14 @@ global.imports = {
                     if (index > -1) {
                         this.children.splice(index, 1);
                     }
+                }
+
+                set_tooltip_text(text) {
+                    this.tooltip_text = text;
+                }
+
+                get_tooltip_text() {
+                    return this.tooltip_text;
                 }
             },
             Label: class MockLabel {

--- a/tests/status-indicator.test.js
+++ b/tests/status-indicator.test.js
@@ -40,6 +40,9 @@ class StatusIndicator extends St.BoxLayout {
             });
             this.add_child(this._textLabel);
         }
+
+        // Set tooltip to show indicator name
+        this.set_tooltip_text(this._name);
     }
 
     setStatus(status) {
@@ -90,6 +93,9 @@ class StatusIndicator extends St.BoxLayout {
         if (this._textLabel) {
             this._textLabel.set_text(this._name);
         }
+
+        // Update tooltip with new name
+        this.set_tooltip_text(this._name);
     }
 }
 
@@ -126,6 +132,10 @@ describe('StatusIndicator', () => {
 
         test('should not create text label when showLabel is false', () => {
             expect(indicator._textLabel).toBeUndefined();
+        });
+
+        test('should set tooltip to indicator name', () => {
+            expect(indicator.tooltip_text).toBe('Test AI');
         });
     });
 
@@ -225,6 +235,11 @@ describe('StatusIndicator', () => {
             expect(() => indicator.setStatus('ready')).not.toThrow();
             expect(() => indicator.setStatus('working')).not.toThrow();
             expect(() => indicator.setStatus('waiting')).not.toThrow();
+        });
+
+        test('should update tooltip when name changes', () => {
+            indicator.updateConfig('Updated AI Name', '✅', '⚠️', '⛔', false);
+            expect(indicator.tooltip_text).toBe('Updated AI Name');
         });
     });
 


### PR DESCRIPTION
- Status indicators now show tooltip with indicator name on hover
- Tooltips update automatically when indicator name changes
- Useful for showing project names, tool names, or process descriptions
- Added test coverage for tooltip functionality
- Updated README to document tooltip feature

Assisted-by: Cursor (Claude)