### PR TITLE
Fix PR checks workflow - remove npm cache and use npm install

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,10 +18,9 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'npm'
         
     - name: Install dependencies
-      run: npm ci
+      run: npm install
       
     - name: Run linter
       run: npm run lint


### PR DESCRIPTION
- Removed npm cache configuration that requires package-lock.json
- Changed from npm ci to npm install for dependency installation
- Fixes workflow failure due to missing lock file

Assisted-by: Cursor (Claude)