### PR TITLE
Add GNOME Shell 48 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "version": 1,
   "url": "https://github.com/jewzaam/gnome-extension-ai-status-indicators",


### PR DESCRIPTION
- Add GNOME Shell version 48 to supported versions in metadata.json
- Resolves compatibility issue with GNOME 48.2

Assisted-by: Cursor (Claude)