### PR TITLE
Implement official GNOME Shell tooltip functionality using label_actor

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -25,4 +25,16 @@
     font-size: 12px;
     color: #ffffff;
     margin-left: 4px;
+}
+
+/* Tooltip styling using GNOME Shell's standard tooltip appearance */
+.tooltip-label {
+    background-color: rgba(0, 0, 0, 0.8);
+    border-radius: 6px;
+    padding: 6px 10px;
+    color: #ffffff;
+    font-size: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    z-index: 1000;
 } 


### PR DESCRIPTION
- Replace deprecated set_tooltip_text with official label_actor approach
- Add _setupTooltip method using GNOME Shell's chrome system
- Add _onHoverChanged for tooltip positioning and show/hide logic
- Add _cleanup method for proper resource management
- Update removeIndicator and clearIndicators to call _cleanup
- Add tooltip styling in stylesheet.css matching GNOME Shell appearance
- Update tests to verify label_actor approach works across all GNOME versions
- Tooltips now work consistently in GNOME Shell 45-48+ using official API

This replaces the custom tooltip implementation with the same approach that GNOME Shell uses internally for its own tooltips.

Assisted-by: Cursor (Claude)