### PR TITLE
Fix ESLint warnings for unused variables and parameters

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -202,7 +202,7 @@ const StatusWidget = GObject.registerClass(
         }
 
         clearIndicators() {
-            for (const [id, indicator] of this._indicators) {
+            for (const [, indicator] of this._indicators) {
                 this._container.remove_child(indicator);
                 indicator._cleanup(); // Clean up tooltip
             }

--- a/prefs.js
+++ b/prefs.js
@@ -273,7 +273,7 @@ export default class StatusWidgetPreferences extends ExtensionPreferences {
         });
     }
 
-    _showAddDialog(window, settings, group) {
+    _showAddDialog(window, settings, _group) {
         const dialog = new Gtk.Dialog({
             title: _('Add Indicator'),
             modal: true,

--- a/tests/extension.test.js
+++ b/tests/extension.test.js
@@ -2,7 +2,6 @@
 // Integration tests for the extension
 const Extension = global.Extension;
 const Main = global.Main;
-const Gio = global.imports.gi.Gio;
 
 // Mock Extension class for testing
 class MockStatusWidgetExtension extends Extension {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -99,7 +99,7 @@ global.imports = {
         },
         Gio: {
             DBusExportedObject: {
-                wrapJSObject: (xml, obj) => ({
+                wrapJSObject: (_xml, _obj) => ({
                     export: jest.fn(),
                     unexport: jest.fn()
                 })
@@ -239,7 +239,7 @@ global.Extension = class MockExtension {
                 return this._connections.get(signal).length - 1;
             },
 
-            disconnect(id) {
+            disconnect(_id) {
                 // Simple mock - doesn't actually disconnect
             }
         };

--- a/tests/status-widget.test.js
+++ b/tests/status-widget.test.js
@@ -86,7 +86,7 @@ class StatusWidget extends PanelMenu.Button {
     }
 
     clearIndicators() {
-        for (const [id, indicator] of this._indicators) {
+        for (const [, indicator] of this._indicators) {
             this._container.remove_child(indicator);
         }
         this._indicators.clear();


### PR DESCRIPTION
- Use array destructuring [, indicator] to ignore unused id in for...of loops
- Prefix unused parameters with underscore (_xml, _obj, _id, _group)
- Remove unused Gio import from tests/extension.test.js
- Clean up all no-unused-vars lint warnings across the codebase

All tests still pass (73/73) across GNOME Shell versions 45-48.

Assisted-by: Cursor (Claude)